### PR TITLE
Delete deads and confirmed from remove_unused_data

### DIFF
--- a/data_organizer.py
+++ b/data_organizer.py
@@ -295,33 +295,23 @@ class DataOrganizer:
         Chile
         - tasa_activos
         - previous
-        - series.confirmados
-        - series.fallecidos
         """
         del self.chile["tasa_activos"]
         del self.chile["previous"]
-        del self.chile["series"]["confirmados"]
-        del self.chile["series"]["fallecidos"]
 
         """
         Regiones
         - tasa_activos
         - previous
-        - series.confirmados
-        - series.fallecidos
         """
         for region in self.chile["regiones"]:
             del self.chile["regiones"][region]["tasa_activos"]
             del self.chile["regiones"][region]["previous"]
-            del self.chile["regiones"][region]["series"]["confirmados"]
-            del self.chile["regiones"][region]["series"]["fallecidos"]
 
         """
         Comunas
         - previous.confirmados
         - previous.fallecidos
-        - series.confirmados
-        - series.fallecidos
         """
 
         # All previous data in regiones
@@ -330,8 +320,6 @@ class DataOrganizer:
                 comuna_obj = self.chile["regiones"][region]["comunas"][comuna]
                 del comuna_obj["previous"]["confirmados"]
                 del comuna_obj["previous"]["fallecidos"]
-                del comuna_obj["series"]["confirmados"]
-                del comuna_obj["series"]["fallecidos"]
 
     def save_data(self):
         with open("./data/chile.json", "w") as outfile:


### PR DESCRIPTION
# Description

Don´t be deleted the deads and confirmed cases on remove_unused_data
The reason is to make posible this feature https://github.com/javierlopeza/covid19entucomuna/pull/20

## Type of change

- [ x] New feature (non-breaking change which adds functionality).

## Checklist

- [ x] PR includes a summary of changes.
- [ x] My code follows the style guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [ x] I have commented my code, particularly in hard-to-understand areas.
- [ x] My commits are written in the [conventional form](https://www.conventionalcommits.org/en/v1.0.0/): `type(context): description`.
- [ x] My commits are linear and ordered (e.g. avoid '_Fix typo_' like commits). More info [here](https://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html).
